### PR TITLE
Fixed bug if lang file is emtpy

### DIFF
--- a/src/Philo/Translate/Console/CleanUpCommand.php
+++ b/src/Philo/Translate/Console/CleanUpCommand.php
@@ -75,7 +75,7 @@ class CleanUpCommand extends Command {
 
 	protected function processGroup($group, $lines)
 	{
-		if(empty($lines) || is_string($lines)) continue;
+		if(empty($lines) || is_string($lines)) return ;
 		array_set($this->missing, $group, array());
 
 		$this->line("Processing $group group...");


### PR DESCRIPTION
Just a quick fix I did find. You cannot return continue from method.
